### PR TITLE
feat: add Design Tools subcategory with Excalidraw, open-pencil, Open Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@
 - [VSCodium](https://github.com/VSCodium/vscodium) - A fully open source distribution of VS Code without proprietary components.
 - [Zed](https://github.com/zed-industries/zed) - A high-performance collaborative editor gaining rapid adoption.
 
+### Design Tools
+
+- [Excalidraw](https://github.com/excalidraw/excalidraw) - Virtual whiteboard for sketching hand-drawn style diagrams with real-time collaboration and infinite canvas.
+- [open-pencil](https://github.com/open-pencil/open-pencil) - AI-native Figma-compatible design editor with headless CLI, MCP server, and design-to-code export.
+- [Open Design](https://github.com/nexu-io/open-design) - Local-first AI design tool with 19 skills and 71 brand-grade design systems for generating web, mobile, and slide artifacts.
+
 ### UI Components
 
 - [8bitcn](https://github.com/TheOrcDev/8bitcn-ui) - Retro 8-bit styled open-source UI component library.


### PR DESCRIPTION
## Why does this project belong on the list?

This PR introduces a new Design Tools subcategory under Web Development, adding three open-source tools that enable developers to design, prototype, and build UIs — a workflow not covered by existing subcategories (Code Editors, UI Components, etc.).

## Checklist

Before submitting, confirm all of the following:

- [x] The project is not already on the list
- [x] The project has been actively maintained within the past 12 months (last commit check)
- [x] The project has at least 50 GitHub stars
- [x] The project is licensed under MIT, Apache-2.0, GPL-2.0, GPL-3.0, LGPL-2.1, LGPL-3.0, or AGPL-3.0
- [x] The source code is fully and publicly available
- [x] No proprietary dependencies are required to run core functionality
- [x] The entry is placed in the most specific existing category

## Entry being added or modified

Paste the exact line(s) added or changed in `README.md`:

```markdown
### Design Tools

- [Excalidraw](https://github.com/excalidraw/excalidraw) - Virtual whiteboard for sketching hand-drawn style diagrams with real-time collaboration and infinite canvas.
- [open-pencil](https://github.com/open-pencil/open-pencil) - AI-native Figma-compatible design editor with headless CLI, MCP server, and design-to-code export.
- [Open Design](https://github.com/nexu-io/open-design) - Local-first AI design tool with 19 skills and 71 brand-grade design systems for generating web, mobile, and slide artifacts.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Design Tools section to the README, featuring Excalidraw, open-pencil, and Open Design resources for web development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->