### PR TITLE
Add: NoteGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@
 - [Joplin](https://github.com/laurent22/joplin) - Note-taking and task management application with sync support.
 - [Logseq](https://github.com/logseq/logseq) - Knowledge management and outlining application.
 - [Markor](https://github.com/gsantner/markor) - Markdown editor and note-taking app for Android.
+- [NoteGen](https://github.com/codexu/note-gen) - Local-first Markdown note-taking app with capture, editing, optional sync, and AI-assisted organization.
 - [Notesnook](https://github.com/streetwriters/notesnook) - Privacy-focused encrypted note-taking app.
 - [Quillpad](https://github.com/quillpad/quillpad) - Minimal Material You note-taking app.
 - [Standard Notes](https://github.com/standardnotes/app) - End-to-end encrypted notes application.


### PR DESCRIPTION
## What changed

Added NoteGen to Mobile Apps → Productivity & Notes.

## Why it belongs

NoteGen is a GPL-3.0 local-first Markdown note-taking app. Its source is fully public, it is actively maintained, it has more than 12,000 GitHub stars, and its core capture, editing, file management, and local Markdown workflow does not require a proprietary service.

## Checks

- `pnpm check-urls` — passed
- `git diff --check` — passed
- Confirmed the entry is alphabetically placed between Markor and Notesnook
- The documented `pnpm sort-resources` command is not defined by the repository's `package.json`; no sorting command was available to run
