### PR TITLE
feat: add hetty project

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@
 - [Responder](https://github.com/lgandx/Responder) - LLMNR, NBT-NS, and MDNS poisoner commonly used in internal network assessments.
 - [sqlmap](https://github.com/sqlmapproject/sqlmap) - Automated SQL injection and database takeover tool.
 - [Wireshark](https://github.com/wireshark/wireshark) - Network protocol analyzer for troubleshooting and packet inspection.
-- [hetty](https://github.com/dstotijn/hetty) - Open source proxy that allows you to modify packets
+- [Hetty](https://github.com/dstotijn/hetty) - Open source proxy that allows you to modify packets.
 
 ### Secrets Management & Encryption
 
@@ -531,7 +531,6 @@
 - [Remix Icon](https://github.com/Remix-Design/RemixIcon) - System-style open-source icon library.
 - [Simple Icons](https://github.com/simple-icons/simple-icons) - Brand and logo icons in SVG format.
 - [Tabler Icons](https://github.com/tabler/tabler-icons) - Large, consistent and actively maintained icon set.
-- [google fonts icons](https://fonts.google.com/icons) - Simple icon pack made by google
 
 ### React UI libraries
 

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@
 - [Remix Icon](https://github.com/Remix-Design/RemixIcon) - System-style open-source icon library.
 - [Simple Icons](https://github.com/simple-icons/simple-icons) - Brand and logo icons in SVG format.
 - [Tabler Icons](https://github.com/tabler/tabler-icons) - Large, consistent and actively maintained icon set.
+- [google fonts icons](https://fonts.google.com/icons) - Simple icon pack made by google
 
 ### React UI libraries
 

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@
 - [Responder](https://github.com/lgandx/Responder) - LLMNR, NBT-NS, and MDNS poisoner commonly used in internal network assessments.
 - [sqlmap](https://github.com/sqlmapproject/sqlmap) - Automated SQL injection and database takeover tool.
 - [Wireshark](https://github.com/wireshark/wireshark) - Network protocol analyzer for troubleshooting and packet inspection.
+- [hetty](https://github.com/dstotijn/hetty) - Open source proxy that allows you to modify packets
 
 ### Secrets Management & Encryption
 


### PR DESCRIPTION
## Why does this project belong on the list?

Hetty is a open source proxy that can intercept, modify, send packets.

## Additional context

Hetty is the opensource alternative to burpsuite

## Checklist

Before submitting, confirm all of the following:

- [x] The project is not already on the list
- [x] The project has been actively maintained within the past 12 months (last commit check)
- [x] The project has at least 50 GitHub stars
- [x] The project is licensed under MIT, Apache-2.0, GPL-2.0, GPL-3.0, LGPL-2.1, LGPL-3.0, or AGPL-3.0
- [x] The source code is fully and publicly available
- [x] No proprietary dependencies are required to run core functionality
- [x] The entry is placed in the most specific existing category

## Entry being added or modified

Paste the exact line(s) added or changed in `README.md`:

```markdown
- [hetty](https://github.com/dstotijn/hetty) - Open source proxy that allows you to modify packets
- [google fonts icons](https://fonts.google.com/icons) - Simple icon pack made by google
```
